### PR TITLE
Fix fake session instantiation

### DIFF
--- a/app/code/community/Aoe/BlackHoleSession/Model/Session.php
+++ b/app/code/community/Aoe/BlackHoleSession/Model/Session.php
@@ -7,7 +7,6 @@ class Aoe_BlackHoleSession_Model_Session extends Mage_Core_Model_Session
 
     public function __construct(array $data)
     {
-        parent::__construct($data);
         if (!empty($_SERVER['HTTP_USER_AGENT'])) {
             $config = Mage::getConfig()->getNode('global/aoeblackholesession');
             $botRegex = (string) $config->descend('bot_regex');
@@ -15,6 +14,7 @@ class Aoe_BlackHoleSession_Model_Session extends Mage_Core_Model_Session
                 $this->isBot = true;
             }
         }
+        parent::__construct($data);
     }
 
     public function getSessionSaveMethod()

--- a/tests/phpunit/SessionTest.php
+++ b/tests/phpunit/SessionTest.php
@@ -1,0 +1,90 @@
+<?php
+class SessionTest extends PHPUnit_Framework_TestCase
+{
+    public function setUp()
+    {
+        $this->nuke();
+        parent::setUp();
+    }
+
+    private function getSessionFiles()
+    {
+        $files = [];
+        foreach (glob(Mage::getBaseDir('session') . '/*') as $file) {
+            if (is_file($file)) {
+                $files[] = $file;
+            }
+        }
+        return $files;
+    }
+
+    public function tearDown()
+    {
+        $this->nuke();
+        parent::tearDown();
+    }
+
+    protected function nuke()
+    {
+        unset($_SESSION);
+        unset($_SERVER['REQUEST_URI']);
+        unset($_SERVER['HTTP_USER_AGENT']);
+
+        foreach ($this->getSessionFiles() as $file) {
+            unlink($file);
+        }
+
+        Mage::reset();
+        Mage::app();
+    }
+
+    public function testFileSessionsStoreData()
+    {
+        /**
+         * @see https://github.com/OpenMage/magento-mirror/blob/magento-1.9/app/code/core/Mage/Core/Controller/Varien/Action.php#L493
+         */
+        Mage::getModel('core/session', array('name' => 'frontend'))->start();
+        session_write_close();
+
+        $this->assertCount(1, $this->getSessionFiles(), 'A session file should exist');
+    }
+
+    public function testFakeSessionsStoreNoData()
+    {
+        Mage::getConfig()->setNode('global/aoeblackholesession/bot_regex', '/^elb-healthchecker/i');
+        $_SERVER['HTTP_USER_AGENT'] = 'elb-healthchecker';
+
+        Mage::getModel('core/session', array('name' => 'frontend'))->start();
+        session_write_close();
+
+        $this->assertCount(0, $this->getSessionFiles(), 'No session file should exist');
+    }
+
+    /**
+     * @dataProvider botDataProvider
+     */
+    public function testUserAgents($botRegex, $userAgent, $expectedSessionSaveMethod, $expectedSessionCount)
+    {
+        Mage::getConfig()->setNode('global/aoeblackholesession/bot_regex', $botRegex);
+        $_SERVER['HTTP_USER_AGENT'] = $userAgent;
+
+        $session = Mage::getModel('core/session', array('name' => 'frontend'))->start();
+
+        $this->assertEquals($expectedSessionSaveMethod, (string)$session->getSessionSaveMethod());
+        session_write_close();
+
+        $this->assertCount(
+            $expectedSessionCount,
+            $this->getSessionFiles(),
+            "The wrong number of session files was encountered"
+        );
+    }
+
+    public function botDataProvider()
+    {
+        return [
+            ['/^elb-healthchecker/i', 'elb-healthchecker', 'user', 0],
+            ['/^elb-healthchecker/i', 'chrome', 'files', 1],
+        ];
+    }
+}

--- a/tests/travis.sh
+++ b/tests/travis.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 DIR_TEST="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-DIR_PROJECT=$(realpath $DIR_TEST/../)
+DIR_PROJECT=$(readlink -f $DIR_TEST/../)
 DIR_TEST_MAGE="$DIR_TEST/magento"
 DIR_TEST_VENDOR="$DIR_TEST/vendor"
 


### PR DESCRIPTION
### Steps

- Add test for session instantiation to prove that `isBot` requests are still instantiating a session. See tests fail.
- Add fix.
- See tests go green.

### Test Failures

Even though we use an user agent which is defined as a `bot`, and even through the `getSessionSaveMethod` returns `user`, a session file is still formed on disk. This means the that the session is actually instantiated regardless of this module.

```bash
There were 2 failures:

1) SessionTest::testFakeSessionsStoreNoData
No session file should exist
Failed asserting that actual size 1 matches expected size 0.
/home/travis/build/AmpersandHQ/Aoe_BlackHoleSession/tests/phpunit/SessionTest.php:60

2) SessionTest::testUserAgents with data set #0 ('/^elb-healthchecker/i', 'elb-healthchecker', 'user', 0)
The wrong number of session files was encountered
Failed asserting that actual size 1 matches expected size 0.
/home/travis/build/AmpersandHQ/Aoe_BlackHoleSession/tests/phpunit/SessionTest.php:80

```

### The Fix

cf7e5f77f9403be1c4dd141dbf66277af2756bc6

Make sure the regex check fires before calling the parent constructor, making the rest of the session login run properly.