### PR TITLE
Fix php notice in dummy session

### DIFF
--- a/app/code/community/Aoe/BlackHoleSession/Model/SessionHandler.php
+++ b/app/code/community/Aoe/BlackHoleSession/Model/SessionHandler.php
@@ -27,7 +27,10 @@ class Aoe_BlackHoleSession_Model_SessionHandler implements SessionHandlerInterfa
 
     public function read($session_id)
     {
-        return self::$sessionData[$session_id];
+        if (isset(self::$sessionData[$session_id])) {
+            return self::$sessionData[$session_id];
+        }
+        return '';
     }
 
     public function write($session_id, $session_data)


### PR DESCRIPTION
```
	/**
	 * Read session data
	 * @link http://php.net/manual/en/sessionhandlerinterface.read.php
	 * @param string $session_id The session id to read data for.
	 * @return string <p>
	 * Returns an encoded string of the read data.
	 * If nothing was read, it must return an empty string.
	 * Note this value is returned internally to PHP for processing.
	 * </p>
	 * @since 5.4.0
	 */
```

As per php doc returns an empty string if not found